### PR TITLE
Prevented unnecessary download of go tar

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Download the Go tarball
   get_url: url={{ go_download_location }}
-           dest=/usr/local/src/
+           dest=/usr/local/src/{{ go_tarball }}
            sha256sum={{ go_tarball_checksum }}
 
 - name: Extract the Go tarball


### PR DESCRIPTION
If the .tar is already there, it won't download it again if the filename is included in the dest.
