### PR TITLE
alter the download location

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-go_download_location: "http://go.googlecode.com/files/{{ go_tarball }}"
+go_download_location: "http://golang.org/dl/{{ go_tarball }}"


### PR DESCRIPTION
Thanks for creating this role.

This fixes the download path. It seems golang moved to their own domain.

Cheers,
