### PR TITLE
allow setting of go path, architecture, and version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-go_version: 1.3.3
+go_version: 1.4
 arch: linux-amd64
 go_tarball: "go{{go_version}}.{{arch}}.tar.gz"
 go_tarball_checksum: "14068fbe349db34b838853a7878621bbd2b24646"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
-go_tarball: "go1.3.2.linux-amd64.tar.gz"
-go_tarball_checksum: "8b20223611adf15bcce6d105dde28ebae972230f5984376c1c5451ae2a4e5778"
-go_version_target: "go version go1.3.2 linux/amd64"
+go_version: 1.3.3
+arch: linux-amd64
+go_tarball: "go{{go_version}}.{{arch}}.tar.gz"
+go_tarball_checksum: "14068fbe349db34b838853a7878621bbd2b24646"
+go_version_target: "go version go{{go_version}} linux/amd64"
+go_path: ~/go

--- a/files/go-path.sh
+++ b/files/go-path.sh
@@ -1,2 +1,0 @@
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:$PATH

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,21 +2,26 @@
 - name: Download the Go tarball
   get_url: url={{ go_download_location }}
            dest=/usr/local/src/{{ go_tarball }}
-           sha256sum={{ go_tarball_checksum }}
 
 - name: Register the current Go version (if any)
   command: /usr/local/go/bin/go version
   ignore_errors: yes
-  register: go_version
+  register: current_go_version
 
 - name: Extract the Go tarball if Go is not yet installed or if it is not the desired version
   command: tar -C /usr/local -xf /usr/local/src/{{ go_tarball }}
-  when: go_version|failed or go_version.stdout != go_version_target
+  when: current_go_version|failed or current_go_version.stdout != go_version_target
 
 - name: Add the Go bin directory to the PATH environment variable for all users
   copy: src=go-bin.sh
         dest=/etc/profile.d
-
 - name: Set GOPATH for all users
-  copy: src=go-path.sh
-        dest=/etc/profile.d
+  template: src=go-path.sh.j2
+            dest=/etc/profile.d/go-path.sh
+- name: create base go path directory structure
+  file: path={{go_path}}/{{item}}
+        state=directory
+  with_items:
+    - src
+    - bin
+    - pkg

--- a/templates/go-path.sh.j2
+++ b/templates/go-path.sh.j2
@@ -1,0 +1,2 @@
+export GOPATH={{go_path}}
+export PATH=$PATH:$GOPATH/bin


### PR DESCRIPTION
Hi!

I just wanted to expose a few more params so I could use this to other versions, or on different architectures.

Something like this:

```yaml
# ...
roles:
  - {role: go, go_path: ~/src/go}
```