### PR TITLE
Copy go tar file from local, or download it from remote & Update go version to 1.3.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+files/go1.3.3.linux-amd64.tar.gz

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-go_tarball: "go1.3.2.linux-amd64.tar.gz"
-go_tarball_checksum: "8b20223611adf15bcce6d105dde28ebae972230f5984376c1c5451ae2a4e5778"
-go_version_target: "go version go1.3.2 linux/amd64"
+go_tarball: "go1.3.3.linux-amd64.tar.gz"
+go_tarball_checksum: "41943288fb9fc5bda9f132b0cf67fefb9cb672d7135b4a87de37372376b9612e"
+go_version_target: "go version go1.3.3 linux/amd64"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,7 @@
   get_url: url={{ go_download_location }}
            dest=/usr/local/src/{{ go_tarball }}
            sha256sum={{ go_tarball_checksum }}
+  environment: proxy_env
   when: copy_go_file|failed
 
 - name: Register the current Go version (if any)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,14 @@
 ---
+- name: Copy Go tarball
+  copy: src={{go_tarball}} dest=/usr/local/src/{{ go_tarball }}
+  register: copy_go_file
+  ignore_errors: yes
+
 - name: Download the Go tarball
   get_url: url={{ go_download_location }}
            dest=/usr/local/src/{{ go_tarball }}
            sha256sum={{ go_tarball_checksum }}
+  when: copy_go_file|failed
 
 - name: Register the current Go version (if any)
   command: /usr/local/go/bin/go version


### PR DESCRIPTION
1. Copy go tar file from local, or download it from remote to reduce the download time
2. Update go version to 1.3.3