### PR TITLE
Don't set "changed" when registering go version

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,7 @@
   command: /usr/local/go/bin/go version
   ignore_errors: yes
   register: go_version
+  changed_when: false
 
 - name: Extract the Go tarball if Go is not yet installed or if it is not the desired version
   command: tar -C /usr/local -xf /usr/local/src/{{ go_tarball }}


### PR DESCRIPTION
Currently, the "Register the current Go version (if any)" registers as "changed" every time it runs.  Set "changed_when: false" ([docs](http://docs.ansible.com/playbooks_error_handling.html#overriding-the-changed-result)) avoids this.