### PR TITLE
Update Go version to 1.4.2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-go_tarball: "go1.3.2.linux-amd64.tar.gz"
-go_tarball_checksum: "8b20223611adf15bcce6d105dde28ebae972230f5984376c1c5451ae2a4e5778"
-go_version_target: "go version go1.3.2 linux/amd64"
+go_tarball: "go1.4.2.linux-amd64.tar.gz"
+go_tarball_checksum: "141b8345932641483c2437bdbd65488a269282ac85f91170805c273f03dd223b"
+go_version_target: "go version go1.4.2 linux/amd64"


### PR DESCRIPTION
Pretty straightforward, updates to the latest version of Go (1.4.2) as of 6/9/2015