### PR TITLE
Make this run in check mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: Extract the Go tarball if Go is not yet installed or if it is not the desired version
   command: tar -C /usr/local -xf /usr/local/src/{{ go_tarball }}
-  when: go_version|failed or go_version.stdout != go_version_target
+  when: go_version|failed or (not go_version|skipped and go_version.stdout != go_version_target)
 
 - name: Add the Go bin directory to the PATH environment variable for all users
   copy: src=go-bin.sh


### PR DESCRIPTION
The role fails when it runs with `ansible-playbook --check`:

```
TASK: [joshualund.golang | Extract the Go tarball if Go is not yet installed or if it is not the desired version] *
**
fatal: [146.148.4.191] => error while evaluating conditional: not go_version|skipped and go_version|failed or go_ve
rsion.stdout != go_version_target

FATAL: all hosts have already failed -- aborting
```

This is because in check mode ansible doesn't execute commands and instead returns an object with a skipped attribute set to true.