### PR TITLE
Remove old installation of go if exists

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,13 @@
   register: go_version
   changed_when: false
 
+- name: Remove old installation of go
+  file: >
+      path=/usr/local/go
+      state=absent
+  when: go_version|failed or go_version.stdout != go_version_target
+    
+
 - name: Extract the Go tarball if Go is not yet installed or not the desired version
   unarchive: src=/usr/local/src/{{ go_tarball }}
              dest=/usr/local


### PR DESCRIPTION
We have had problems when an upgrade is done and it mixes versions. 
This PR fixes that.