### PR TITLE
Version auto discovery

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,14 @@
 ---
 # Set download location to an overridable var if you want to use an internal mirror
-go_download_location: "https://storage.googleapis.com/golang/{{ go_tarball }}"
-go_tarball: "go1.7.1.linux-amd64.tar.gz"
-go_tarball_checksum: "sha256:43ad621c9b014cde8db17393dc108378d37bc853aa351a6c74bf6432c1bbd182"
-go_version_target: "go version go1.7.1 linux/amd64"
+#go_download_location: "https://storage.googleapis.com/golang/{{ go_tarball }}"
+
+# go_version, go_tarball, and its checksum can be set by a deployer to
+# force a specific version.
+# if they are ALL not set, version will be autodiscovered.
+#   the version will be found thanks to github releases.
+#   the shasum will be fetched from "{{ go_download_location }}/{{ go_tarball }}.sha256"
+#go_version: "1.7.1"
+#go_tarball: "go{{ go_version }}.linux-amd64.tar.gz"
+#go_tarball_checksum: "sha256:43ad621c9b014cde8db17393dc108378d37bc853aa351a6c74bf6432c1bbd182"
+go_version_target: "go version go{{ go_version }} linux/amd64"
 set_go_path: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+# Set download location to an overridable var if you want to use an internal mirror
+go_download_location: "https://storage.googleapis.com/golang/{{ go_tarball }}"
 go_tarball: "go1.7.1.linux-amd64.tar.gz"
 go_tarball_checksum: "sha256:43ad621c9b014cde8db17393dc108378d37bc853aa351a6c74bf6432c1bbd182"
 go_version_target: "go version go1.7.1 linux/amd64"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,28 +1,50 @@
 ---
+- name: Discover the latest version
+  shell:
+    curl https://api.github.com/repos/golang/go/git/refs/tags/ | egrep 'ref.*refs/tags/go([0-9.]+)",' | egrep -o "[0-9.]+" | sort | tail -n 1
+  register: latest_release
+  changed_when: False
+  when:
+    - not go_tarball is defined
+    - not go_tarball_checksum is defined
+    - not go_download_location is defined
+
+- name: Setting facts for autodiscovered version
+  set_fact:
+    go_version: "{{ latest_release.stdout_lines[0] }}"
+    go_tarball: "go{{ latest_release.stdout_lines[0] }}.linux-amd64.tar.gz"
+  when: not latest_release | skipped
+
+- name: Setting facts based on previous autodiscovered facts
+  set_fact:
+    go_tarball_checksum: "sha256:{{ lookup('url',go_download_buckets_url+go_tarball+'.sha256') }}"
+    go_download_location: "{{ go_download_buckets_url }}{{ go_tarball }}"
+  when: not latest_release | skipped
+
 - name: Download the Go tarball
   get_url:
     url: "{{ go_download_location }}"
-    dest: /usr/local/src/{{ go_tarball }}
+    dest: "/usr/local/src/"
     checksum: "{{ go_tarball_checksum }}"
 
 - name: Register the current Go version (if any)
   command: /usr/local/go/bin/go version
   ignore_errors: yes
-  register: go_version
+  register: current_go_version
   changed_when: false
 
 - name: Remove old installation of Go
   file:
     path: /usr/local/go
     state: absent
-  when: go_version|failed or go_version.stdout != go_version_target
+  when: current_go_version|failed or current_go_version.stdout != go_version_target
 
 - name: Extract the Go tarball if Go is not yet installed or not the desired version
   unarchive:
     src: /usr/local/src/{{ go_tarball }}
     dest: /usr/local
     copy: no
-  when: go_version|failed or go_version.stdout != go_version_target
+  when: current_go_version|failed or current_go_version.stdout != go_version_target
 
 - name: Add the Go bin directory to the PATH environment variable for all users
   copy:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-go_download_location: "https://storage.googleapis.com/golang/{{ go_tarball }}"
+

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-
+go_download_buckets_url: "https://storage.googleapis.com/golang/"


### PR DESCRIPTION
This will allow the upgrading of versions automatically, without the
need of changes in the role. Recently, golang made public the
storage bucket where the tar.gz and .sha256 files for releases are
published. This commit makes use of this in an automated fashion
