### PR TITLE
Updates defaults to Go 1.8.1 release.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-go_tarball: "go1.7.1.linux-amd64.tar.gz"
-go_tarball_checksum: "sha256:43ad621c9b014cde8db17393dc108378d37bc853aa351a6c74bf6432c1bbd182"
-go_version_target: "go version go1.7.1 linux/amd64"
+go_tarball: "go1.8.1.linux-amd64.tar.gz"
+go_tarball_checksum: "sha256:a579ab19d5237e263254f1eac5352efcf1d70b9dacadb6d6bb12b0911ede8994"
+go_version_target: "go version go1.8.1 linux/amd64"
 set_go_path: true


### PR DESCRIPTION
Go 1.8.1 is [the latest stable release](https://golang.org/doc/devel/release.html#go1.8.minor). Pending a more robust solution to keeping the latest release synchronized (e.g. https://github.com/jlund/ansible-go/pull/28) this PR updates the static defaults to 1.8.1 as a quick fix.