### PR TITLE
avoid unnecessary tarball downloading

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Download the Go tarball
+  get_url:
+    url: "{{ go_download_location }}"
+    dest: /usr/local/src/{{ go_tarball }}
+    checksum: "{{ go_tarball_checksum }}"
+
+- name: Remove old installation of Go
+  file:
+    path: /usr/local/go
+    state: absent
+
+- name: Extract the Go tarball if Go is not yet installed or not the desired version
+  unarchive:
+    src: /usr/local/src/{{ go_tarball }}
+    dest: /usr/local
+    copy: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,4 @@
 ---
-- name: Download the Go tarball
-  get_url:
-    url: "{{ go_download_location }}"
-    dest: /usr/local/src/{{ go_tarball }}
-    checksum: "{{ go_tarball_checksum }}"
 
 - name: Register the current Go version (if any)
   command: /usr/local/go/bin/go version
@@ -11,17 +6,7 @@
   register: go_version
   changed_when: false
 
-- name: Remove old installation of Go
-  file:
-    path: /usr/local/go
-    state: absent
-  when: go_version|failed or go_version.stdout != go_version_target
-
-- name: Extract the Go tarball if Go is not yet installed or not the desired version
-  unarchive:
-    src: /usr/local/src/{{ go_tarball }}
-    dest: /usr/local
-    copy: no
+- include: install.yml
   when: go_version|failed or go_version.stdout != go_version_target
 
 - name: Add the Go bin directory to the PATH environment variable for all users


### PR DESCRIPTION
This avoids unnecessarily downloading the big tarball every time the play runs. I also moved that task and a couple others into `install.yml` to avoid repetitive complicated conditionals.